### PR TITLE
only defines "be_profane" if RSpec is loaded

### DIFF
--- a/lib/obscenity/rspec_matcher.rb
+++ b/lib/obscenity/rspec_matcher.rb
@@ -1,5 +1,7 @@
-RSpec::Matchers.define :be_profane do |expected|
-  match do |actual|
-    Obscenity.profane?(actual) == expected
+if defined?(RSpec::Matchers)
+  RSpec::Matchers.define :be_profane do |expected|
+    match do |actual|
+      Obscenity.profane?(actual) == expected
+    end
   end
 end


### PR DESCRIPTION
Loading the gem in a rails project without RSpec loaded is not possible, so I propose this if-block to check if any RSpec::Matchers class is defined.
