### PR TITLE
add yaml requirement for new ruby versions

### DIFF
--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -1,3 +1,5 @@
+require 'yaml' if RUBY_VERSION >= '1.9'
+
 module Obscenity
   class Base
     class << self


### PR DESCRIPTION
In order for obscenity to work with Ruby versions 1.9 and up, the 'yaml' module must be explicitly required.
