### PR TITLE
Consider underscores when checking for profanity

### DIFF
--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -21,7 +21,7 @@ module Obscenity
       def profane?(text)
         return(false) unless text.to_s.size >= 3
         blacklist.each do |foul|
-          return(true) if text =~ /\b#{foul}\b/i && !whitelist.include?(foul)
+          return(true) if text =~ /(_|\b)#{foul}(_|\b)/i && !whitelist.include?(foul)
         end
         false
       end

--- a/test/test_base.rb
+++ b/test/test_base.rb
@@ -54,6 +54,12 @@ class TestBase < Test::Unit::TestCase
           assert Obscenity::Base.profane?('biatch')
           assert !Obscenity::Base.profane?('hello')
         end
+
+        should "validate the profanity of multiple words based on the default list" do
+          assert Obscenity::Base.profane?('ass fuck')
+          assert Obscenity::Base.profane?('fuck-nuts')
+          assert Obscenity::Base.profane?('fuck_nuts')
+        end
       end
       context "with custom blacklist config" do
         setup { Obscenity::Base.blacklist = ['ass', 'word'] }


### PR DESCRIPTION
This PR takes underscores into consideration.

Before:

```ruby
irb(main):003:0> Obscenity.profane? "shit_head"
=> false
```

Now:

```ruby
irb(main):003:0> Obscenity.profane? "shit_head"
=> true
```