### PR TITLE
Whitelist should check the input text

### DIFF
--- a/lib/obscenity/base.rb
+++ b/lib/obscenity/base.rb
@@ -21,7 +21,7 @@ module Obscenity
       def profane?(text)
         return(false) unless text.to_s.size >= 3
         blacklist.each do |foul|
-          return(true) if text =~ /\b#{foul}\b/i && !whitelist.include?(foul)
+          return(true) if text =~ /\b#{foul}\b/i && !whitelist.include?(text)
         end
         false
       end
@@ -29,7 +29,7 @@ module Obscenity
       def sanitize(text)
         return(text) unless text.to_s.size >= 3
         blacklist.each do |foul|
-          text.gsub!(/\b#{foul}\b/i, replace(foul)) unless whitelist.include?(foul)
+          text.gsub!(/\b#{foul}\b/i, replace(foul)) unless whitelist.include?(text)
         end
         @scoped_replacement = nil
         text
@@ -44,7 +44,7 @@ module Obscenity
         words = []
         return(words) unless text.to_s.size >= 3
         blacklist.each do |foul|
-          words << foul if text =~ /\b#{foul}\b/i && !whitelist.include?(foul)
+          words << foul if text =~ /\b#{foul}\b/i && !whitelist.include?(text)
         end
         words.uniq
       end


### PR DESCRIPTION
The whitelist should be checking the input text instead of an item from the blacklist for the following reasons:
1. There is no point to have the same word both in blacklist and whitelist. If the word shouldn't be considered as profane, simply remove it from the blacklist.

2. By checking the input text in the whitelist will make Regex working better in the blacklist, e.g. "suckdicks" should be profane, but "DickSmith"(An Australian brand) should not be. So if we have "\w*dicks\w*" in the blacklist and "DickSmith" in the whitelist, we can easily by pass the check for "DickSmith" without miss checking any profane words contain "dicks".